### PR TITLE
Fix bot environment loading

### DIFF
--- a/bot_main.py
+++ b/bot_main.py
@@ -97,6 +97,8 @@ async def cancel_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     return ConversationHandler.END
 
 def main():
+    # Load environment variables from a .env file if present
+    load_dotenv()
     BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 
     app = ApplicationBuilder().token(BOT_TOKEN).build()


### PR DESCRIPTION
## Summary
- ensure the Telegram bot loads variables from `.env`

## Testing
- `python -m py_compile bot_main.py cleaner.py exporter.py getter.py parser.py qr_reader.py templates/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68529db549a483329bf4844fce279323