### PR TITLE
Load env at import and add parser test

### DIFF
--- a/bot_main.py
+++ b/bot_main.py
@@ -13,6 +13,9 @@ import json
 from getter import get_json_data
 from dotenv import load_dotenv
 
+# Load environment variables from a .env file if present
+load_dotenv()
+
 # Enable logging
 logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
@@ -113,8 +116,6 @@ async def cancel_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     return ConversationHandler.END
 
 def main():
-    # Load environment variables from a .env file if present
-    load_dotenv()
     BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 
     app = ApplicationBuilder().token(BOT_TOKEN).build()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,21 @@
+import json
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from parser import ReceiptParser
+
+
+def test_parse_euro_number(tmp_path, monkeypatch):
+    data = {
+        "journal": "",
+        "invoiceRequest": {},
+        "invoiceResult": {}
+    }
+    dummy = tmp_path / "dummy.json"
+    dummy.write_text(json.dumps(data), encoding='utf-8')
+
+    # prevent side effects in __init__
+    monkeypatch.setattr(ReceiptParser, '_is_tax_id_new', lambda self: False)
+    parser = ReceiptParser(str(dummy))
+    assert parser._parse_euro_number('1.234,56') == 1234.56


### PR DESCRIPTION
## Summary
- load environment variables from `.env` when `bot_main` is imported
- add test for parsing European-formatted numbers
- revert earlier changes to exporter docstring and table template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68529db55cd08332b292fe421e451ca8