### PR TITLE
Add duplicate receipt notification

### DIFF
--- a/assistant/parser.py
+++ b/assistant/parser.py
@@ -26,7 +26,8 @@ class ReceiptParser:
         self.output_matrix = {}
 
         self._load_data()
-        if self._is_tax_id_new():
+        self.is_tax_id_new = self._is_tax_id_new()
+        if self.is_tax_id_new:
             self._parse_journal()
 
     def _load_data(self):

--- a/bot_main.py
+++ b/bot_main.py
@@ -85,7 +85,9 @@ async def qrcode_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         get_json_data(receipt_link)
         logger.info("Received receipt link: %s", receipt_link)
         for file in os.listdir("raw_data"):
-            ReceiptParser(json_path=os.path.join("raw_data", file))
+            parser = ReceiptParser(json_path=os.path.join("raw_data", file))
+            if not parser.is_tax_id_new:
+                await update.message.reply_text("This receipt has already been processed.")
             remove_file(os.path.join("raw_data", file))  # Remove the raw data file after parsing
     else:
         await update.message.reply_text("No QR code found in the image.")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -19,3 +19,17 @@ def test_parse_euro_number(tmp_path, monkeypatch):
     monkeypatch.setattr(ReceiptParser, '_is_tax_id_new', lambda self: False)
     parser = ReceiptParser(str(dummy))
     assert parser._parse_euro_number('1.234,56') == 1234.56
+
+
+def test_is_tax_id_new_property(tmp_path, monkeypatch):
+    data = {
+        "journal": "",
+        "invoiceRequest": {},
+        "invoiceResult": {}
+    }
+    dummy = tmp_path / "dummy.json"
+    dummy.write_text(json.dumps(data), encoding='utf-8')
+
+    monkeypatch.setattr(ReceiptParser, '_is_tax_id_new', lambda self: False)
+    parser = ReceiptParser(str(dummy))
+    assert parser.is_tax_id_new is False


### PR DESCRIPTION
## Summary
- expose result of `_is_tax_id_new` as `is_tax_id_new` on `ReceiptParser`
- notify user in `bot_main` if a receipt was already processed
- add unit test for new attribute

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685567539dd88332bd13fe6a88bfb9ba