### PR TITLE
Fix parser tests

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,8 +1,5 @@
 import json
-import os
-import sys
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from assistant.parser import ReceiptParser
 
 
@@ -16,7 +13,7 @@ def test_parse_euro_number(tmp_path, monkeypatch):
     dummy.write_text(json.dumps(data), encoding='utf-8')
 
     # prevent side effects in __init__
-    monkeypatch.setattr(ReceiptParser, '_is_tax_id_new', lambda self: False)
+    monkeypatch.setattr(ReceiptParser, '_check_if_tax_id_new', lambda self: False)
     parser = ReceiptParser(str(dummy))
     assert parser._parse_euro_number('1.234,56') == 1234.56
 
@@ -30,6 +27,6 @@ def test_is_tax_id_new_property(tmp_path, monkeypatch):
     dummy = tmp_path / "dummy.json"
     dummy.write_text(json.dumps(data), encoding='utf-8')
 
-    monkeypatch.setattr(ReceiptParser, '_is_tax_id_new', lambda self: False)
+    monkeypatch.setattr(ReceiptParser, '_check_if_tax_id_new', lambda self: False)
     parser = ReceiptParser(str(dummy))
     assert parser.is_tax_id_new is False


### PR DESCRIPTION
## Summary
- simplify test imports
- patch `_check_if_tax_id_new` in tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888db7910e08332a0f4d36b4f1bb2dc