### PR TITLE
Add user dataclass retrieval via get_user

### DIFF
--- a/assistant/db_handler.py
+++ b/assistant/db_handler.py
@@ -1,5 +1,18 @@
 import os
 import sqlite3
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class User:
+    """Simple representation of a bot user."""
+
+    id: int
+    user_id: int
+    googlesheet_key: Optional[str]
+    is_owner: int
+    registered_at: str
 
 
 def db_connect():
@@ -36,13 +49,29 @@ def table_init():
     conn.close()
 
 
-def add_user(user_id: int):
+def get_user(user_id: int) -> Optional[User]:
+    """Retrieve a user from the database."""
+    conn = db_connect()
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT id, user_id, googlesheet_key, is_owner, registered_at "
+        "FROM users WHERE user_id = ?",
+        (user_id,),
+    )
+    row = cursor.fetchone()
+    conn.close()
+    if row:
+        return User(*row)
+    return None
+
+
+def add_user(user_id: int) -> None:
     """Insert a new user into the users table if it does not already exist."""
     conn = db_connect()
     cursor = conn.cursor()
     cursor.execute(
         "INSERT OR IGNORE INTO users (user_id) VALUES (?)",
-        (user_id,)
+        (user_id,),
     )
     conn.commit()
     conn.close()

--- a/bot_main.py
+++ b/bot_main.py
@@ -8,7 +8,7 @@ from assistant.qr_reader import read_qr
 from assistant.parser import ReceiptParser
 from assistant.cleaner import remove_file, move_to_archive
 from assistant.exporter import append_voucher_data, append_item_data, reset_sheets, prepare_sheets, initialize_tables
-from assistant.db_handler import table_init, add_user
+from assistant.db_handler import table_init, add_user, get_user, User
 
 import json
 from assistant.getter import get_json_data
@@ -54,6 +54,9 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         one_time_keyboard=True
     )
     add_user(update.effective_user.id)
+    user = get_user(update.effective_user.id)
+    if user:
+        context.user_data["user"] = user
     await update.message.reply_text(
         "Welcome! Press a button below or type a command.",
         reply_markup=keyboard

--- a/tests/test_db_handler.py
+++ b/tests/test_db_handler.py
@@ -1,0 +1,26 @@
+import sqlite3
+import os
+
+import pytest
+
+from assistant import db_handler
+
+
+def _tmp_db(tmp_path):
+    """Return a connection to a temporary database inside tmp_path."""
+    db_file = tmp_path / "test.db"
+    return sqlite3.connect(db_file)
+
+
+def test_get_user_returns_dataclass_after_add(tmp_path, monkeypatch):
+    """add_user shouldn't return anything but get_user should return User."""
+    monkeypatch.setattr(db_handler, "db_connect", lambda: _tmp_db(tmp_path))
+
+    db_handler.table_init()
+
+    result = db_handler.add_user(42)
+    assert result is None
+
+    user = db_handler.get_user(42)
+    assert isinstance(user, db_handler.User)
+    assert user.user_id == 42


### PR DESCRIPTION
## Summary
- store users with dataclass in `db_handler`
- `add_user` only inserts a record, `get_user` retrieves the dataclass
- set user context in `/start` using `get_user`
- update tests for new behaviour

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b315ae3d08332ac670b25f5034a4f