### PR TITLE
Construct User on bot start and improve parser input handling

### DIFF
--- a/assistant/db_handler.py
+++ b/assistant/db_handler.py
@@ -1,5 +1,7 @@
 import os
 import sqlite3
+from typing import Optional
+
 from assistant.class_user import User
 
 
@@ -29,7 +31,7 @@ def table_init():
             user_telegram_id INTEGER,
             qr_code TEXT,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (user_id) REFERENCES users (user_id)
+            FOREIGN KEY (user_telegram_id) REFERENCES users (user_telegram_id)
         )
     ''')
 
@@ -43,7 +45,7 @@ def get_user(user_telegram_id: int) -> Optional[User]:
     cursor = conn.cursor()
     cursor.execute(
         "SELECT id, user_telegram_id, googlesheet_key, is_owner, registered_at "
-        "FROM users WHERE user_id = ?",
+        "FROM users WHERE user_telegram_id = ?",
         (user_telegram_id,),
     )
     row = cursor.fetchone()
@@ -63,6 +65,12 @@ def add_user(user_telegram_id: int) -> None:
     )
     conn.commit()
     conn.close()
+
+
+def construct_user(user_telegram_id: int) -> Optional[User]:
+    """Ensure a user exists in the database and return it."""
+    add_user(user_telegram_id)
+    return get_user(user_telegram_id)
 
 def add_googlesheet_key(user_telegram_id: int, googlesheet_key: str) -> None:
     """Update the googlesheet_key for a user in the users table."""

--- a/assistant/parser.py
+++ b/assistant/parser.py
@@ -11,9 +11,13 @@ ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 logger = logging.getLogger(__name__)
 
 class ReceiptParser:
-    def __init__(self, json_file: dict[str, Any]) -> None:
+    def __init__(self, json_file: str | dict[str, Any]) -> None:
         """Load a raw receipt JSON file for parsing."""
-        self.json_file = json_file
+        if isinstance(json_file, str):
+            with open(json_file, "r", encoding="utf-8") as f:
+                self.json_file = json.load(f)
+        else:
+            self.json_file = json_file
         self.journal = ""
         self.lines = []
         self.items = []
@@ -156,5 +160,5 @@ class ReceiptParser:
         }
 
     def to_dict(self) -> dict[str, Any] | None:
-            """Return the processed output_matrix as a dict."""
-            return self.output_matrix
+        """Return the processed output_matrix as a dict."""
+        return self.output_matrix

--- a/bot_main.py
+++ b/bot_main.py
@@ -9,7 +9,7 @@ from assistant.qr_reader import read_qr
 from assistant.parser import ReceiptParser
 from assistant.cleaner import remove_file, move_to_archive
 from assistant.exporter import append_voucher_data, append_item_data, reset_sheets, prepare_sheets, initialize_tables
-from assistant.db_handler import table_init, add_user, get_user, User
+from assistant.db_handler import table_init, construct_user, User
 
 import json
 from assistant.getter import get_json_data
@@ -54,8 +54,7 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         resize_keyboard=True,
         one_time_keyboard=True
     )
-    add_user(update.effective_user.id)
-    user = get_user(update.effective_user.id)
+    user = construct_user(update.effective_user.id)
     if user:
         context.user_data["user"] = user
     await update.message.reply_text(


### PR DESCRIPTION
## Summary
- centralize user creation and retrieval via `construct_user`
- load `User` in `bot_main` when `/start` is used
- allow `ReceiptParser` to load from file path or dictionary

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c43f9358388332af20150a2244021e