### PR TITLE
Add command to display user sheet key

### DIFF
--- a/bot_main.py
+++ b/bot_main.py
@@ -126,6 +126,19 @@ async def prepare_sheet_command(update: Update, context: ContextTypes.DEFAULT_TY
         logger.error(f"Error during sheet preparation: {e}")
         await update.message.reply_text(f"An error occurred: {e}", reply_markup=main_keyboard)
 
+# Handler for the /sheet_key command
+async def sheet_key_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Send the user's Google Sheet key back to them."""
+    user = context.user_data.get("user")
+    if not user:
+        await update.message.reply_text("Please run /start first to initialize your account.")
+        return
+
+    if user.googlesheet_key:
+        await update.message.reply_text(f"Your Google Sheet key: {user.googlesheet_key}")
+    else:
+        await update.message.reply_text("No Google Sheet key found for your account.")
+
 def main():
     BOT_TOKEN = TELEGRAM_BOT_TOKEN
     table_init()
@@ -148,6 +161,7 @@ def main():
     app.add_handler(CommandHandler("start", start_command))
     app.add_handler(CommandHandler("hello", hello_command))
     app.add_handler(CommandHandler("prepare_sheet", prepare_sheet_command))
+    app.add_handler(CommandHandler("sheet_key", sheet_key_command))
     app.add_handler(conv_handler)
 
     logger.info("Bot is running. Press Ctrl+C to stop.")

--- a/tests/test_bot_main.py
+++ b/tests/test_bot_main.py
@@ -1,0 +1,64 @@
+import sqlite3
+import types
+import sys
+import os
+import pytest
+
+# Ensure the parent directory is on the path for importing project modules
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+# Provide dummy modules to satisfy imports in bot_main dependencies
+sys.modules.setdefault("cv2", types.SimpleNamespace())
+sys.modules.setdefault("pyzbar", types.SimpleNamespace())
+sys.modules.setdefault("pyzbar.pyzbar", types.SimpleNamespace(decode=lambda *args, **kwargs: []))
+sys.modules.setdefault("assistant.qr_reader", types.SimpleNamespace(read_qr=lambda *args, **kwargs: None))
+
+from assistant import db_handler
+from bot_main import sheet_key_command
+
+
+class DummyMessage:
+    def __init__(self):
+        self.text = None
+    async def reply_text(self, text, **kwargs):
+        self.text = text
+
+
+class DummyUpdate:
+    def __init__(self, user_id: int):
+        self.effective_user = types.SimpleNamespace(id=user_id)
+        self.message = DummyMessage()
+
+
+class DummyContext:
+    def __init__(self):
+        self.user_data = {}
+import asyncio
+
+
+def test_sheet_key_command_outputs_key(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_handler, "db_connect", lambda: sqlite3.connect(tmp_path / "test.db"))
+    db_handler.table_init()
+    db_handler.add_user(1)
+    db_handler.add_googlesheet_key(1, "sheet123")
+
+    update = DummyUpdate(1)
+    context = DummyContext()
+    context.user_data["user"] = db_handler.get_user(1)
+
+    asyncio.run(sheet_key_command(update, context))
+
+    assert update.message.text == "Your Google Sheet key: sheet123"
+
+
+def test_sheet_key_command_requires_start(tmp_path, monkeypatch):
+    """Ensure the command prompts users to run /start before use."""
+    monkeypatch.setattr(db_handler, "db_connect", lambda: sqlite3.connect(tmp_path / "test.db"))
+    db_handler.table_init()
+
+    update = DummyUpdate(1)
+    context = DummyContext()
+
+    asyncio.run(sheet_key_command(update, context))
+
+    assert update.message.text == "Please run /start first to initialize your account."


### PR DESCRIPTION
## Summary
- add `/sheet_key` command to return the user's Google Sheet key
- require the user to have run `/start` before using `/sheet_key`
- cover the new command with unit tests

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c530a67ee0833299e1491e0b808947