### PR TITLE
Add command to store user Google Sheet key

### DIFF
--- a/bot_main.py
+++ b/bot_main.py
@@ -9,7 +9,7 @@ from assistant.qr_reader import read_qr
 from assistant.parser import ReceiptParser
 from assistant.cleaner import remove_file, move_to_archive
 from assistant.exporter import append_voucher_data, append_item_data, reset_sheets, prepare_sheets, initialize_tables
-from assistant.db_handler import table_init, construct_user, User
+from assistant.db_handler import table_init, construct_user, User, add_googlesheet_key
 
 import json
 from assistant.getter import get_json_data
@@ -26,8 +26,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Define states for ConversationHandler
-WAITING_FOR_IMAGE = 1
+# Define states for ConversationHandlers
+WAITING_FOR_IMAGE, WAITING_FOR_SHEET_KEY = range(2)
 
 main_keyboard = ReplyKeyboardMarkup(
     [['/start']],
@@ -126,6 +126,27 @@ async def prepare_sheet_command(update: Update, context: ContextTypes.DEFAULT_TY
         logger.error(f"Error during sheet preparation: {e}")
         await update.message.reply_text(f"An error occurred: {e}", reply_markup=main_keyboard)
 
+# Handler for the /add_google_sheet_key command
+async def add_google_sheet_key_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Prompt the user to provide a Google Sheet key."""
+    user = context.user_data.get("user")
+    if not user:
+        await update.message.reply_text("Please run /start first to initialize your account.")
+        return ConversationHandler.END
+
+    await update.message.reply_text("Please send your Google Sheet key.")
+    return WAITING_FOR_SHEET_KEY
+
+
+async def receive_google_sheet_key(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Store the Google Sheet key sent by the user."""
+    user = context.user_data.get("user")
+    key = update.message.text.strip()
+    add_googlesheet_key(user.user_id, key)
+    user.googlesheet_key = key
+    await update.message.reply_text("Google Sheet key saved!")
+    return ConversationHandler.END
+
 # Handler for the /sheet_key command
 async def sheet_key_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Send the user's Google Sheet key back to them."""
@@ -163,6 +184,17 @@ def main():
     app.add_handler(CommandHandler("prepare_sheet", prepare_sheet_command))
     app.add_handler(CommandHandler("sheet_key", sheet_key_command))
     app.add_handler(conv_handler)
+
+    sheet_key_conv_handler = ConversationHandler(
+        entry_points=[CommandHandler("add_google_sheet_key", add_google_sheet_key_command)],
+        states={
+            WAITING_FOR_SHEET_KEY: [
+                MessageHandler(filters.TEXT & ~filters.COMMAND, receive_google_sheet_key)
+            ],
+        },
+        fallbacks=[],
+    )
+    app.add_handler(sheet_key_conv_handler)
 
     logger.info("Bot is running. Press Ctrl+C to stop.")
     app.run_polling()

--- a/tests/test_bot_main.py
+++ b/tests/test_bot_main.py
@@ -14,7 +14,12 @@ sys.modules.setdefault("pyzbar.pyzbar", types.SimpleNamespace(decode=lambda *arg
 sys.modules.setdefault("assistant.qr_reader", types.SimpleNamespace(read_qr=lambda *args, **kwargs: None))
 
 from assistant import db_handler
-from bot_main import sheet_key_command
+from bot_main import (
+    sheet_key_command,
+    add_google_sheet_key_command,
+    receive_google_sheet_key,
+    WAITING_FOR_SHEET_KEY,
+)
 
 
 class DummyMessage:
@@ -60,5 +65,40 @@ def test_sheet_key_command_requires_start(tmp_path, monkeypatch):
     context = DummyContext()
 
     asyncio.run(sheet_key_command(update, context))
+
+    assert update.message.text == "Please run /start first to initialize your account."
+
+
+def test_add_google_sheet_key_flow_updates_key(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_handler, "db_connect", lambda: sqlite3.connect(tmp_path / "test.db"))
+    db_handler.table_init()
+    db_handler.add_user(1)
+
+    update = DummyUpdate(1)
+    context = DummyContext()
+    context.user_data["user"] = db_handler.get_user(1)
+
+    state = asyncio.run(add_google_sheet_key_command(update, context))
+
+    assert state == WAITING_FOR_SHEET_KEY
+    assert update.message.text == "Please send your Google Sheet key."
+    assert db_handler.get_googlesheet_key(1) is None
+
+    update_key = DummyUpdate(1)
+    update_key.message.text = "sheet456"
+    asyncio.run(receive_google_sheet_key(update_key, context))
+
+    assert db_handler.get_googlesheet_key(1) == "sheet456"
+    assert update_key.message.text == "Google Sheet key saved!"
+
+
+def test_add_google_sheet_key_command_requires_start(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_handler, "db_connect", lambda: sqlite3.connect(tmp_path / "test.db"))
+    db_handler.table_init()
+
+    update = DummyUpdate(1)
+    context = DummyContext()
+
+    asyncio.run(add_google_sheet_key_command(update, context))
 
     assert update.message.text == "Please run /start first to initialize your account."


### PR DESCRIPTION
## Summary
- prompt users for a Google Sheet key after `/add_google_sheet_key`
- save the provided key through a follow-up message handler
- test command flow for successful key storage and start requirement

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c69c84b5c08332869c8d383d592510