### PR TITLE
Use per-user Google Sheet keys

### DIFF
--- a/assistant/config.py
+++ b/assistant/config.py
@@ -4,7 +4,6 @@ from dotenv import load_dotenv
 load_dotenv()
 
 TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
-GOOGLE_SHEET_KEY = os.getenv("GOOGLE_SHEET_KEY")
 SERVICE_ACCOUNT_FILE = os.getenv("SERVICE_ACCOUNT_FILE", "google_service.json")
 DB_PATH = os.getenv("DB_PATH", "db/bot.db")
 

--- a/assistant/exporter.py
+++ b/assistant/exporter.py
@@ -4,11 +4,9 @@ from google.oauth2.service_account import Credentials
 import logging
 from templates.table_creation_template import TABLE_CREATION_BODY
 from templates.sheets_preparation_template import SHEETS_PREPARATION_BODY
-from .config import GOOGLE_SHEET_KEY, SERVICE_ACCOUNT_FILE, SCOPES
+from .config import SERVICE_ACCOUNT_FILE, SCOPES
 
 logger = logging.getLogger(__name__)
-
-sheet_id = GOOGLE_SHEET_KEY
 
 _service = None
 
@@ -23,10 +21,8 @@ def get_service():
         _service = build("sheets", "v4", credentials=credentials)
     return _service
 
-def initialize_tables():
-    """
-    Initializes the Google Sheet by clearing existing data and setting up headers.
-    """
+def initialize_tables(sheet_id: str):
+    """Initialize a Google Sheet with headers."""
     service = get_service()
     sheet = service.spreadsheets()
     # Clear existing data
@@ -40,12 +36,8 @@ def initialize_tables():
     logger.info("Sheet initialized with headers.")
 
 
-def reset_sheets():
-    """
-    Resets the spreadsheet to its original state:
-    - Ensures only one sheet remains with sheetId 0.
-    - Clears all data from the remaining sheet and renames it to 'Sheet1'.
-    """
+def reset_sheets(sheet_id: str):
+    """Reset the spreadsheet to a single empty sheet."""
     service = get_service()
     sheet = service.spreadsheets()
     spreadsheet = service.spreadsheets().get(spreadsheetId=sheet_id).execute()
@@ -101,12 +93,9 @@ def reset_sheets():
     logger.info("Spreadsheet reset: only one empty sheet with id 0 remains.")
 
 
-def prepare_sheets():
-    """
-    Creates a new sheet (tab) in the Google Spreadsheet.
-    :param sheet_name: Name of the new sheet/tab.
-    """
-    
+def prepare_sheets(sheet_id: str):
+    """Create a new sheet (tab) in the Google Spreadsheet."""
+
     service = get_service()
     response = service.spreadsheets().batchUpdate(
         spreadsheetId=sheet_id,
@@ -116,7 +105,7 @@ def prepare_sheets():
     return response
 
 
-def append_item_data(data):
+def append_item_data(sheet_id: str, data):
     body = {
         'values': data["items"]
     }
@@ -133,7 +122,7 @@ def append_item_data(data):
 
     logger.info("%s cells appended.", result.get('updates', {}).get('updatedCells', 0))
 
-def append_voucher_data(data):
+def append_voucher_data(sheet_id: str, data):
     body = {
         'values': data["voucher_data"]
     }

--- a/bot_main.py
+++ b/bot_main.py
@@ -93,8 +93,14 @@ async def qrcode_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text("No QR code found in the image, please try to send a clearer image.")
         return WAITING_FOR_IMAGE
     if parsed_json:
-        append_item_data(parsed_json)
-        append_voucher_data(parsed_json)
+        user = context.user_data.get("user")
+        if not user or not user.googlesheet_key:
+            await update.message.reply_text(
+                "No Google Sheet key found. Please set one using /add_google_sheet_key."
+            )
+            return ConversationHandler.END
+        append_item_data(user.googlesheet_key, parsed_json)
+        append_voucher_data(user.googlesheet_key, parsed_json)
 
         
         
@@ -116,11 +122,21 @@ async def cancel_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 # Handler for the /prepare_sheets command
 async def prepare_sheet_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await update.message.reply_text("Preparing sheets... Please wait.")
+    user = context.user_data.get("user")
+    if not user or not user.googlesheet_key:
+        await update.message.reply_text(
+            "No Google Sheet key found. Please set one using /add_google_sheet_key.",
+            reply_markup=main_keyboard,
+        )
+        return
     try:
-        reset_sheets()
-        prepare_sheets()
-        initialize_tables()
-        await update.message.reply_text("Sheets have been reset and initialized successfully!", reply_markup=main_keyboard)
+        reset_sheets(user.googlesheet_key)
+        prepare_sheets(user.googlesheet_key)
+        initialize_tables(user.googlesheet_key)
+        await update.message.reply_text(
+            "Sheets have been reset and initialized successfully!",
+            reply_markup=main_keyboard,
+        )
     except Exception as e:
         logger.error(f"Error during sheet preparation: {e}")
         await update.message.reply_text(f"An error occurred: {e}", reply_markup=main_keyboard)


### PR DESCRIPTION
## Summary
- Remove environment-based Google Sheet key
- Parameterize exporter to accept sheet IDs per user
- Fetch sheet IDs from database when exporting or preparing sheets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6b19ba2c48332b13aa11a47289cb4