### PR TITLE
Store processed receipts in database

### DIFF
--- a/assistant/db_handler.py
+++ b/assistant/db_handler.py
@@ -96,3 +96,28 @@ def get_googlesheet_key(user_telegram_id: int) -> str | None:
     if row:
         return row[0]
     return None
+
+
+def add_processed_receipt(user_telegram_id: int, receipt_number: str) -> None:
+    """Store a processed receipt number for the given user."""
+    conn = db_connect()
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO processed_receipts (user_telegram_id, receipt_number) VALUES (?, ?)",
+        (user_telegram_id, receipt_number),
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_processed_receipts(user_telegram_id: int) -> set[str]:
+    """Retrieve all processed receipt numbers for a given user."""
+    conn = db_connect()
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT receipt_number FROM processed_receipts WHERE user_telegram_id = ?",
+        (user_telegram_id,),
+    )
+    receipts = {row[0] for row in cursor.fetchall()}
+    conn.close()
+    return receipts

--- a/assistant/parser.py
+++ b/assistant/parser.py
@@ -2,22 +2,22 @@
 
 import json
 import logging
-import os
 import re
 from typing import Any
 
-ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+from assistant.db_handler import add_processed_receipt, get_processed_receipts
 
 logger = logging.getLogger(__name__)
 
 class ReceiptParser:
-    def __init__(self, json_file: str | dict[str, Any]) -> None:
+    def __init__(self, json_file: str | dict[str, Any], user_telegram_id: int | None = None) -> None:
         """Load a raw receipt JSON file for parsing."""
         if isinstance(json_file, str):
             with open(json_file, "r", encoding="utf-8") as f:
                 self.json_file = json.load(f)
         else:
             self.json_file = json_file
+        self.user_telegram_id = user_telegram_id
         self.journal = ""
         self.lines = []
         self.items = []
@@ -50,30 +50,18 @@ class ReceiptParser:
         self.total_amount = result.get("totalAmount")
         self.invoice_number = result.get("invoiceNumber")
 
-    def _archive_tax_id(self):
-        """
-        Appends the current tax_id to the 'processed_receipts' file in the archive folder.
-        Each tax_id is written on a new line.
-        """
-        archive_dir = os.path.join(ROOT_DIR, "archive")
-        os.makedirs(archive_dir, exist_ok=True)
-        processed_file = os.path.join(archive_dir, "processed_receipts")
-        with open(processed_file, "a", encoding="utf-8") as f:
-            f.write(f"{self.invoice_number}\n")
+    def _archive_tax_id(self) -> None:
+        """Store the current invoice number as processed for the user."""
+        if self.user_telegram_id is None or self.invoice_number is None:
+            return
+        add_processed_receipt(self.user_telegram_id, str(self.invoice_number))
 
-    def _check_if_tax_id_new(self):
-        """
-        Checks if the current tax_id is already in the 'processed_receipts' file.
-        Returns True if it is NOT present (i.e., it's new), False otherwise.
-        """
-        archive_dir = os.path.join(ROOT_DIR, "archive")
-        processed_file = os.path.join(archive_dir, "processed_receipts")
-        if not os.path.isfile(processed_file):
-            return True  # File doesn't exist, so tax_id is new
-
-        with open(processed_file, "r", encoding="utf-8") as f:
-            invoice_numbers = {line.strip() for line in f}
-        return str(self.invoice_number) not in invoice_numbers
+    def _check_if_tax_id_new(self) -> bool:
+        """Check if the current invoice number has already been processed."""
+        if self.user_telegram_id is None or self.invoice_number is None:
+            return True
+        processed = get_processed_receipts(self.user_telegram_id)
+        return str(self.invoice_number) not in processed
             
 
     def _parse_euro_number(self, s: str) -> float:

--- a/bot_main.py
+++ b/bot_main.py
@@ -83,7 +83,11 @@ async def qrcode_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text("QR code found! Processing receipt...")
         logger.info("Received receipt link: %s", receipt_link)
         raw_data = get_json_data(receipt_link)
-        parser = ReceiptParser(json_file=raw_data)
+        user = context.user_data.get("user")
+        if not user:
+            await update.message.reply_text("Please run /start first to initialize your account.")
+            return ConversationHandler.END
+        parser = ReceiptParser(json_file=raw_data, user_telegram_id=user.user_id)
         if not parser.is_tax_id_new:
             await update.message.reply_text("This receipt has already been processed before.")
             return ConversationHandler.END
@@ -93,10 +97,9 @@ async def qrcode_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text("No QR code found in the image, please try to send a clearer image.")
         return WAITING_FOR_IMAGE
     if parsed_json:
-        user = context.user_data.get("user")
         if not user or not user.googlesheet_key:
             await update.message.reply_text(
-                "No Google Sheet key found. Please set one using /add_google_sheet_key."
+                "No Google Sheet key found. Please set one using /add_google_sheet_key.",
             )
             return ConversationHandler.END
         append_item_data(user.googlesheet_key, parsed_json)

--- a/tests/test_db_handler.py
+++ b/tests/test_db_handler.py
@@ -24,3 +24,19 @@ def test_get_user_returns_dataclass_after_add(tmp_path, monkeypatch):
     user = db_handler.get_user(42)
     assert isinstance(user, db_handler.User)
     assert user.user_id == 42
+
+
+def test_processed_receipts_functions(tmp_path, monkeypatch):
+    """Ensure processed receipts can be stored and retrieved per user."""
+    monkeypatch.setattr(db_handler, "db_connect", lambda: _tmp_db(tmp_path))
+
+    db_handler.table_init()
+    db_handler.add_user(1)
+    db_handler.add_processed_receipt(1, "123")
+    db_handler.add_processed_receipt(1, "456")
+
+    receipts = db_handler.get_processed_receipts(1)
+    assert receipts == {"123", "456"}
+
+    db_handler.add_user(2)
+    assert db_handler.get_processed_receipts(2) == set()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -14,7 +14,7 @@ def test_parse_euro_number(tmp_path, monkeypatch):
 
     # prevent side effects in __init__
     monkeypatch.setattr(ReceiptParser, '_check_if_tax_id_new', lambda self: False)
-    parser = ReceiptParser(str(dummy))
+    parser = ReceiptParser(str(dummy), user_telegram_id=1)
     assert parser._parse_euro_number('1.234,56') == 1234.56
 
 
@@ -28,5 +28,5 @@ def test_is_tax_id_new_property(tmp_path, monkeypatch):
     dummy.write_text(json.dumps(data), encoding='utf-8')
 
     monkeypatch.setattr(ReceiptParser, '_check_if_tax_id_new', lambda self: False)
-    parser = ReceiptParser(str(dummy))
+    parser = ReceiptParser(str(dummy), user_telegram_id=1)
     assert parser.is_tax_id_new is False


### PR DESCRIPTION
## Summary
- add helper functions to record and fetch processed receipts in SQLite
- update parser to track processed receipt numbers via the database instead of files
- adjust QR handler to supply user id when parsing receipts
- add tests for database receipt tracking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6cca08d30833299f250141bdf0bb9