### PR TITLE
feat: parse Google Sheet key from shared link

### DIFF
--- a/assistant/db_handler.py
+++ b/assistant/db_handler.py
@@ -3,6 +3,7 @@ import sqlite3
 from typing import Optional
 
 from assistant.class_user import User
+from assistant.google_sheets import extract_sheet_key
 
 
 def db_connect():
@@ -72,16 +73,18 @@ def construct_user(user_telegram_id: int) -> Optional[User]:
     add_user(user_telegram_id)
     return get_user(user_telegram_id)
 
-def add_googlesheet_key(user_telegram_id: int, googlesheet_key: str) -> None:
-    """Update the googlesheet_key for a user in the users table."""
+def add_googlesheet_key(user_telegram_id: int, key_or_url: str) -> str:
+    """Update the googlesheet_key for a user, parsing it from a URL if needed."""
+    key = extract_sheet_key(key_or_url) or key_or_url
     conn = db_connect()
     cursor = conn.cursor()
     cursor.execute(
         "UPDATE users SET googlesheet_key = ? WHERE user_telegram_id = ?",
-        (googlesheet_key, user_telegram_id),
+        (key, user_telegram_id),
     )
     conn.commit()
     conn.close()
+    return key
 
 def get_googlesheet_key(user_telegram_id: int) -> str | None:
     """Retrieve the googlesheet_key for a user from the users table."""

--- a/assistant/google_sheets.py
+++ b/assistant/google_sheets.py
@@ -1,0 +1,12 @@
+import re
+
+
+def extract_sheet_key(link: str) -> str | None:
+    """Extract the Google Sheet key from a full URL.
+
+    Returns the key found between ``spreadsheets/d/`` and the next ``/``.
+    """
+    match = re.search(r"/spreadsheets/d/([a-zA-Z0-9-_]+)", link)
+    if match:
+        return match.group(1)
+    return None

--- a/bot_main.py
+++ b/bot_main.py
@@ -153,15 +153,15 @@ async def add_google_sheet_key_command(update: Update, context: ContextTypes.DEF
         await update.message.reply_text("Please run /start first to initialize your account.")
         return ConversationHandler.END
 
-    await update.message.reply_text("Please send your Google Sheet key.")
+    await update.message.reply_text("Please send a link to your Google Sheet.")
     return WAITING_FOR_SHEET_KEY
 
 
 async def store_google_sheet_key(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Store the Google Sheet key sent by the user."""
     user = context.user_data.get("user")
-    key = update.message.text.strip()
-    add_googlesheet_key(user.user_id, key)
+    raw_input = update.message.text.strip()
+    key = add_googlesheet_key(user.user_id, raw_input)
     user.googlesheet_key = key
     await update.message.reply_text("Google Sheet key saved!")
     return ConversationHandler.END

--- a/tests/test_bot_main.py
+++ b/tests/test_bot_main.py
@@ -14,7 +14,7 @@ sys.modules.setdefault("pyzbar.pyzbar", types.SimpleNamespace(decode=lambda *arg
 sys.modules.setdefault("assistant.qr_reader", types.SimpleNamespace(read_qr=lambda *args, **kwargs: None))
 
 from assistant import db_handler
-from bot_main import sheet_key_command
+from bot_main import sheet_key_command, store_google_sheet_key
 
 
 class DummyMessage:
@@ -62,3 +62,22 @@ def test_sheet_key_command_requires_start(tmp_path, monkeypatch):
     asyncio.run(sheet_key_command(update, context))
 
     assert update.message.text == "Please run /start first to initialize your account."
+
+
+def test_store_google_sheet_key_extracts_key_from_link(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_handler, "db_connect", lambda: sqlite3.connect(tmp_path / "test.db"))
+    db_handler.table_init()
+    db_handler.add_user(1)
+    update = DummyUpdate(1)
+    context = DummyContext()
+    context.user_data["user"] = db_handler.get_user(1)
+
+    url = (
+        "https://docs.google.com/spreadsheets/d/10s_m17fznodfg0uosbZ0LFbqX8zUxLlMkF__0oOsxpo"
+        "/edit?pli=1&gid=1#gid=1"
+    )
+    update.message.text = url
+    asyncio.run(store_google_sheet_key(update, context))
+
+    user = db_handler.get_user(1)
+    assert user.googlesheet_key == "10s_m17fznodfg0uosbZ0LFbqX8zUxLlMkF__0oOsxpo"


### PR DESCRIPTION
## Summary
- Move Google Sheet key extraction into new `assistant/google_sheets` helper
- Parse and store the sheet key within `add_googlesheet_key`
- Simplify bot handler to delegate parsing to the database layer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c82a70c3b483329ac5a5352adbcf14