### PR TITLE
Ensure Google Sheet owners are tracked and enforced

### DIFF
--- a/assistant/class_user.py
+++ b/assistant/class_user.py
@@ -9,5 +9,5 @@ class User:
     id: int
     user_id: int
     googlesheet_key: Optional[str]
-    is_owner: int
+    googlesheet_owner: int
     registered_at: str

--- a/assistant/db_handler.py
+++ b/assistant/db_handler.py
@@ -6,6 +6,10 @@ from assistant.class_user import User
 from assistant.input_handler import extract_sheet_key
 
 
+class GoogleSheetOwnershipError(ValueError):
+    """Raised when a Google Sheet key is already owned by another user."""
+
+
 def db_connect():
     os.makedirs("db", exist_ok=True)
     conn = sqlite3.connect("db/bot.db")
@@ -45,7 +49,7 @@ def get_user(user_telegram_id: int) -> Optional[User]:
     conn = db_connect()
     cursor = conn.cursor()
     cursor.execute(
-        "SELECT id, user_telegram_id, googlesheet_key, is_owner, registered_at "
+        "SELECT id, user_telegram_id, googlesheet_key, googlesheet_owner, registered_at "
         "FROM users WHERE user_telegram_id = ?",
         (user_telegram_id,),
     )
@@ -74,17 +78,35 @@ def construct_user(user_telegram_id: int) -> Optional[User]:
     return get_user(user_telegram_id)
 
 def add_googlesheet_key(user_telegram_id: int, url: str) -> str:
-    """Update the googlesheet_key for a user, parsing it from a URL."""
+    """Update the googlesheet_key for a user, parsing it from a URL.
+
+    Raises:
+        GoogleSheetOwnershipError: If the provided key is already owned by
+            another user.
+    """
+
     key = extract_sheet_key(url) or url
     conn = db_connect()
-    cursor = conn.cursor()
-    cursor.execute(
-        "UPDATE users SET googlesheet_key = ? WHERE user_telegram_id = ?",
-        (key, user_telegram_id),
-    )
-    conn.commit()
-    conn.close()
-    return key
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT user_telegram_id FROM users WHERE googlesheet_key = ? AND googlesheet_owner = 1",
+            (key,),
+        )
+        owner_row = cursor.fetchone()
+        if owner_row and owner_row[0] != user_telegram_id:
+            raise GoogleSheetOwnershipError(
+                "That Google Sheet key is already owned by another user."
+            )
+
+        cursor.execute(
+            "UPDATE users SET googlesheet_key = ?, googlesheet_owner = 1 WHERE user_telegram_id = ?",
+            (key, user_telegram_id),
+        )
+        conn.commit()
+        return key
+    finally:
+        conn.close()
 
 def get_googlesheet_key(user_telegram_id: int) -> str | None:
     """Retrieve the googlesheet_key for a user from the users table."""

--- a/bot_main.py
+++ b/bot_main.py
@@ -9,7 +9,13 @@ from assistant.qr_reader import read_qr
 from assistant.parser import ReceiptParser
 from assistant.cleaner import remove_file, move_to_archive
 from assistant.exporter import append_voucher_data, append_item_data, reset_sheets, prepare_sheets, initialize_tables
-from assistant.db_handler import table_init, construct_user, add_googlesheet_key, get_user
+from assistant.db_handler import (
+    table_init,
+    construct_user,
+    add_googlesheet_key,
+    get_user,
+    GoogleSheetOwnershipError,
+)
 import json
 from assistant.getter import get_json_data
 from dotenv import load_dotenv
@@ -160,9 +166,19 @@ async def add_google_sheet_key_command(update: Update, context: ContextTypes.DEF
 async def store_google_sheet_key(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Store the Google Sheet key sent by the user."""
     user = context.user_data.get("user")
+    if not user:
+        await update.message.reply_text("Please run /start first to initialize your account.")
+        return ConversationHandler.END
+
     raw_input = update.message.text.strip()
-    key = add_googlesheet_key(user.user_id, raw_input)
+    try:
+        key = add_googlesheet_key(user.user_id, raw_input)
+    except GoogleSheetOwnershipError as exc:
+        await update.message.reply_text(str(exc))
+        return ConversationHandler.END
+
     user.googlesheet_key = key
+    user.googlesheet_owner = 1
     await update.message.reply_text("Google Sheet key saved!")
     return ConversationHandler.END
 

--- a/tests/test_bot_main.py
+++ b/tests/test_bot_main.py
@@ -81,3 +81,24 @@ def test_store_google_sheet_key_extracts_key_from_link(tmp_path, monkeypatch):
 
     user = db_handler.get_user(1)
     assert user.googlesheet_key == "10s_m17fznodfg0uosbZ0LFbqX8zUxLlMkF__0oOsxpo"
+    assert user.googlesheet_owner == 1
+
+
+def test_store_google_sheet_key_rejects_duplicate_owned_key(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_handler, "db_connect", lambda: sqlite3.connect(tmp_path / "test.db"))
+    db_handler.table_init()
+    db_handler.add_user(1)
+    db_handler.add_user(2)
+    db_handler.add_googlesheet_key(1, "sheet123")
+
+    update = DummyUpdate(2)
+    context = DummyContext()
+    context.user_data["user"] = db_handler.get_user(2)
+
+    update.message.text = "sheet123"
+    asyncio.run(store_google_sheet_key(update, context))
+
+    assert update.message.text == "That Google Sheet key is already owned by another user."
+    user = db_handler.get_user(2)
+    assert user.googlesheet_key is None
+    assert user.googlesheet_owner == 0

--- a/tests/test_db_handler.py
+++ b/tests/test_db_handler.py
@@ -26,6 +26,28 @@ def test_get_user_returns_dataclass_after_add(tmp_path, monkeypatch):
     assert user.user_id == 42
 
 
+def test_add_googlesheet_key_sets_owner_and_blocks_duplicates(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_handler, "db_connect", lambda: _tmp_db(tmp_path))
+
+    db_handler.table_init()
+    db_handler.add_user(1)
+    db_handler.add_user(2)
+
+    key = db_handler.add_googlesheet_key(1, "sheet123")
+    assert key == "sheet123"
+
+    owner = db_handler.get_user(1)
+    assert owner.googlesheet_key == "sheet123"
+    assert owner.googlesheet_owner == 1
+
+    with pytest.raises(db_handler.GoogleSheetOwnershipError):
+        db_handler.add_googlesheet_key(2, "sheet123")
+
+    non_owner = db_handler.get_user(2)
+    assert non_owner.googlesheet_key is None
+    assert non_owner.googlesheet_owner == 0
+
+
 def test_processed_receipts_functions(tmp_path, monkeypatch):
     """Ensure processed receipts can be stored and retrieved per user."""
     monkeypatch.setattr(db_handler, "db_connect", lambda: _tmp_db(tmp_path))


### PR DESCRIPTION
## Summary
- track Google Sheet ownership on the user model and database lookup
- prevent assigning a Google Sheet key that is already owned by another user and mark successful assignments as owned
- surface ownership conflicts to the bot and cover the new behavior with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c83804c4a08332bee2b1d28d3ceb7b