### PR TITLE
Add join Google Sheet flow for existing sheets

### DIFF
--- a/assistant/db_handler.py
+++ b/assistant/db_handler.py
@@ -8,6 +8,10 @@ from assistant.input_handler import extract_sheet_key
 
 class GoogleSheetOwnershipError(ValueError):
     """Raised when a Google Sheet key is already owned by another user."""
+
+
+class GoogleSheetJoinError(ValueError):
+    """Raised when a user cannot join a Google Sheet."""
 def db_connect():
     os.makedirs("db", exist_ok=True)
     conn = sqlite3.connect("db/bot.db")
@@ -110,6 +114,58 @@ def add_googlesheet_key(user_telegram_id: int, url: str) -> str:
                 googlesheet_owner = 1
             """,
             (user_telegram_id, key),
+        )
+        conn.commit()
+        return key
+    finally:
+        conn.close()
+
+
+def join_googlesheet_key(user_telegram_id: int, url: str) -> str:
+    """Assign an existing Google Sheet key to a user who is joining a sheet.
+
+    The helper verifies that the sheet is already owned by someone before
+    linking it to the requesting user. Joined users are marked with
+    ``googlesheet_owner`` set to ``0`` unless they already own the sheet.
+
+    Raises:
+        GoogleSheetJoinError: If the sheet key is not registered to any owner.
+    """
+
+    key = extract_sheet_key(url) or url
+    conn = db_connect()
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT user_telegram_id FROM users
+            WHERE googlesheet_key = ? AND googlesheet_owner = 1
+            """,
+            (key,),
+        )
+        owner_row = cursor.fetchone()
+        if not owner_row:
+            raise GoogleSheetJoinError(
+                "This Google Sheet key is not registered to any owner. "
+                "Please ask the owner to add it first."
+            )
+
+        cursor.execute(
+            "SELECT googlesheet_owner FROM users WHERE user_telegram_id = ?",
+            (user_telegram_id,),
+        )
+        user_row = cursor.fetchone()
+        owner_flag = 1 if user_row and user_row[0] == 1 else 0
+
+        cursor.execute(
+            """
+            INSERT INTO users (user_telegram_id, googlesheet_key, googlesheet_owner)
+            VALUES (?, ?, ?)
+            ON CONFLICT(user_telegram_id) DO UPDATE SET
+                googlesheet_key = excluded.googlesheet_key,
+                googlesheet_owner = excluded.googlesheet_owner
+            """,
+            (user_telegram_id, key, owner_flag),
         )
         conn.commit()
         return key

--- a/bot_main.py
+++ b/bot_main.py
@@ -13,8 +13,10 @@ from assistant.db_handler import (
     table_init,
     construct_user,
     add_googlesheet_key,
+    join_googlesheet_key,
     get_user,
     GoogleSheetOwnershipError,
+    GoogleSheetJoinError,
 )
 import json
 from assistant.getter import get_json_data
@@ -32,7 +34,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # Define states for ConversationHandler
-WAITING_FOR_IMAGE, WAITING_FOR_SHEET_KEY = range(2)
+WAITING_FOR_IMAGE, WAITING_FOR_SHEET_KEY, WAITING_FOR_JOIN_SHEET_KEY = range(3)
 
 main_keyboard = ReplyKeyboardMarkup(
     [['/start']],
@@ -185,6 +187,40 @@ async def store_google_sheet_key(update: Update, context: ContextTypes.DEFAULT_T
     await update.message.reply_text("Google Sheet key saved!")
     return ConversationHandler.END
 
+
+async def join_google_sheet_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Prompt the user to provide a Google Sheet key to join."""
+    user = context.user_data.get("user")
+    if not user:
+        await update.message.reply_text("Please run /start first to initialize your account.")
+        return ConversationHandler.END
+
+    await update.message.reply_text("Please send a link to the Google Sheet you wish to join.")
+    return WAITING_FOR_JOIN_SHEET_KEY
+
+
+async def store_join_google_sheet_key(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Store a Google Sheet key for a user joining an existing sheet."""
+    user = context.user_data.get("user")
+    if not user:
+        await update.message.reply_text("Please run /start first to initialize your account.")
+        return ConversationHandler.END
+
+    raw_input = update.message.text.strip()
+    try:
+        key = join_googlesheet_key(user.user_id, raw_input)
+    except GoogleSheetJoinError:
+        await update.message.reply_text(
+            "This Google Sheet key is not registered to any owner. Please ask the owner to add it first."
+        )
+        return ConversationHandler.END
+
+    user.googlesheet_key = key
+    if user.googlesheet_owner != 1:
+        user.googlesheet_owner = 0
+    await update.message.reply_text("Joined Google Sheet successfully!")
+    return ConversationHandler.END
+
 # Handler for the /sheet_key command
 async def sheet_key_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Send the user's Google Sheet key back to them."""
@@ -233,6 +269,17 @@ def main():
         fallbacks=[],
     )
     app.add_handler(sheet_key_conv_handler)
+
+    join_sheet_conv_handler = ConversationHandler(
+        entry_points=[CommandHandler("join_googlesheet", join_google_sheet_command)],
+        states={
+            WAITING_FOR_JOIN_SHEET_KEY: [
+                MessageHandler(filters.TEXT & ~filters.COMMAND, store_join_google_sheet_key)
+            ],
+        },
+        fallbacks=[],
+    )
+    app.add_handler(join_sheet_conv_handler)
 
 
     logger.info("Bot is running. Press Ctrl+C to stop.")

--- a/tests/test_bot_main.py
+++ b/tests/test_bot_main.py
@@ -14,12 +14,16 @@ sys.modules.setdefault("pyzbar.pyzbar", types.SimpleNamespace(decode=lambda *arg
 sys.modules.setdefault("assistant.qr_reader", types.SimpleNamespace(read_qr=lambda *args, **kwargs: None))
 
 from assistant import db_handler
-from bot_main import sheet_key_command, store_google_sheet_key
+from bot_main import sheet_key_command, store_google_sheet_key, store_join_google_sheet_key
 
 
 OWNERSHIP_MESSAGE = (
     "This Google Sheet key is already linked to another account. "
     "Please ask the current owner to release it or choose a different sheet."
+)
+
+JOIN_MESSAGE = (
+    "This Google Sheet key is not registered to any owner. Please ask the owner to add it first."
 )
 
 
@@ -105,6 +109,44 @@ def test_store_google_sheet_key_rejects_duplicate_owned_key(tmp_path, monkeypatc
     asyncio.run(store_google_sheet_key(update, context))
 
     assert update.message.text == OWNERSHIP_MESSAGE
+    user = db_handler.get_user(2)
+    assert user.googlesheet_key is None
+    assert user.googlesheet_owner == 0
+
+
+def test_store_join_google_sheet_key_links_existing_sheet(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_handler, "db_connect", lambda: sqlite3.connect(tmp_path / "test.db"))
+    db_handler.table_init()
+    db_handler.add_user(1)
+    db_handler.add_user(2)
+    db_handler.add_googlesheet_key(1, "sheet123")
+
+    update = DummyUpdate(2)
+    context = DummyContext()
+    context.user_data["user"] = db_handler.get_user(2)
+
+    update.message.text = "sheet123"
+    asyncio.run(store_join_google_sheet_key(update, context))
+
+    user = db_handler.get_user(2)
+    assert user.googlesheet_key == "sheet123"
+    assert user.googlesheet_owner == 0
+    assert update.message.text == "Joined Google Sheet successfully!"
+
+
+def test_store_join_google_sheet_key_requires_registered_owner(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_handler, "db_connect", lambda: sqlite3.connect(tmp_path / "test.db"))
+    db_handler.table_init()
+    db_handler.add_user(2)
+
+    update = DummyUpdate(2)
+    context = DummyContext()
+    context.user_data["user"] = db_handler.get_user(2)
+
+    update.message.text = "sheet123"
+    asyncio.run(store_join_google_sheet_key(update, context))
+
+    assert update.message.text == JOIN_MESSAGE
     user = db_handler.get_user(2)
     assert user.googlesheet_key is None
     assert user.googlesheet_owner == 0

--- a/tests/test_db_handler.py
+++ b/tests/test_db_handler.py
@@ -11,6 +11,10 @@ OWNERSHIP_MESSAGE = (
     "Please ask the current owner to release it or choose a different sheet."
 )
 
+JOIN_MESSAGE = (
+    "This Google Sheet key is not registered to any owner. Please ask the owner to add it first."
+)
+
 
 def _tmp_db(tmp_path):
     """Return a connection to a temporary database inside tmp_path."""
@@ -69,6 +73,42 @@ def test_add_googlesheet_key_creates_user_with_owner_flag(tmp_path, monkeypatch)
     assert created is not None
     assert created.googlesheet_key == "sheet99"
     assert created.googlesheet_owner == 1
+
+
+def test_join_googlesheet_key_adds_existing_key(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_handler, "db_connect", lambda: _tmp_db(tmp_path))
+
+    db_handler.table_init()
+    db_handler.add_user(1)
+    db_handler.add_user(2)
+
+    db_handler.add_googlesheet_key(1, "sheet123")
+
+    joined = db_handler.join_googlesheet_key(2, "https://docs.google.com/spreadsheets/d/sheet123/edit")
+    assert joined == "sheet123"
+
+    owner = db_handler.get_user(1)
+    assert owner.googlesheet_owner == 1
+
+    joined_user = db_handler.get_user(2)
+    assert joined_user.googlesheet_key == "sheet123"
+    assert joined_user.googlesheet_owner == 0
+
+
+def test_join_googlesheet_key_requires_existing_owner(tmp_path, monkeypatch):
+    monkeypatch.setattr(db_handler, "db_connect", lambda: _tmp_db(tmp_path))
+
+    db_handler.table_init()
+    db_handler.add_user(2)
+
+    with pytest.raises(db_handler.GoogleSheetJoinError) as excinfo:
+        db_handler.join_googlesheet_key(2, "sheet123")
+
+    assert str(excinfo.value) == JOIN_MESSAGE
+
+    user = db_handler.get_user(2)
+    assert user.googlesheet_key is None
+    assert user.googlesheet_owner == 0
 
 
 def test_processed_receipts_functions(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add a join_googlesheet command that mirrors the add flow and links an existing sheet to the caller
- extend the database layer with a helper that validates ownership before attaching the sheet to new users
- cover the new behaviour with database and bot handler tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c85d7af9408332a089ba2766e503c9