### PR TITLE
Add Google Sheets graph initialization

### DIFF
--- a/assistant/exporter.py
+++ b/assistant/exporter.py
@@ -4,6 +4,7 @@ from google.oauth2.service_account import Credentials
 import logging
 from templates.table_creation_template import TABLE_CREATION_BODY
 from templates.sheets_preparation_template import SHEETS_PREPARATION_BODY
+from templates.graph_creation_template import GRAPH_CREATION_BODY
 from .config import SERVICE_ACCOUNT_FILE, SCOPES
 
 logger = logging.getLogger(__name__)
@@ -103,6 +104,18 @@ def prepare_sheets(sheet_id: str):
     ).execute()
     logger.info("New sheet created.")
     return response
+
+
+def initialize_graphs(sheet_id: str):
+    """Create pivot tables and charts for analytics."""
+
+    service = get_service()
+    service.spreadsheets().batchUpdate(
+        spreadsheetId=sheet_id,
+        body=GRAPH_CREATION_BODY,
+    ).execute()
+
+    logger.info("Graphs initialized.")
 
 
 def append_item_data(sheet_id: str, data):

--- a/bot_main.py
+++ b/bot_main.py
@@ -8,7 +8,14 @@ from telegram.ext import (
 from assistant.qr_reader import read_qr
 from assistant.parser import ReceiptParser
 from assistant.cleaner import remove_file, move_to_archive
-from assistant.exporter import append_voucher_data, append_item_data, reset_sheets, prepare_sheets, initialize_tables
+from assistant.exporter import (
+    append_voucher_data,
+    append_item_data,
+    reset_sheets,
+    prepare_sheets,
+    initialize_tables,
+    initialize_graphs,
+)
 from assistant.db_handler import (
     table_init,
     construct_user,
@@ -149,6 +156,7 @@ async def prepare_sheet_command(update: Update, context: ContextTypes.DEFAULT_TY
         reset_sheets(user.googlesheet_key)
         prepare_sheets(user.googlesheet_key)
         initialize_tables(user.googlesheet_key)
+        initialize_graphs(user.googlesheet_key)
         await update.message.reply_text(
             "Sheets have been reset and initialized successfully!",
             reply_markup=build_main_keyboard(user),
@@ -191,8 +199,23 @@ async def store_google_sheet_key(update: Update, context: ContextTypes.DEFAULT_T
 
     user.googlesheet_key = key
     user.googlesheet_owner = 1
+
+    try:
+        reset_sheets(key)
+        prepare_sheets(key)
+        initialize_tables(key)
+        initialize_graphs(key)
+    except Exception as e:
+        logger.error(f"Error during sheet initialization: {e}")
+        await update.message.reply_text(
+            "Google Sheet key saved, but there was an error preparing the sheet."
+            f" Please try again later or use /prepare_sheets.\nError: {e}",
+            reply_markup=build_main_keyboard(user),
+        )
+        return ConversationHandler.END
+
     await update.message.reply_text(
-        "Google Sheet key saved!",
+        "Google Sheet key saved and sheets prepared!",
         reply_markup=build_main_keyboard(user),
     )
     return ConversationHandler.END

--- a/tests/test_bot_main.py
+++ b/tests/test_bot_main.py
@@ -14,6 +14,7 @@ sys.modules.setdefault("pyzbar.pyzbar", types.SimpleNamespace(decode=lambda *arg
 sys.modules.setdefault("assistant.qr_reader", types.SimpleNamespace(read_qr=lambda *args, **kwargs: None))
 
 from assistant import db_handler
+import bot_main
 from bot_main import sheet_key_command, store_google_sheet_key, store_join_google_sheet_key
 
 
@@ -92,6 +93,7 @@ def test_store_google_sheet_key_extracts_key_from_link(tmp_path, monkeypatch):
     user = db_handler.get_user(1)
     assert user.googlesheet_key == "10s_m17fznodfg0uosbZ0LFbqX8zUxLlMkF__0oOsxpo"
     assert user.googlesheet_owner == 1
+    assert update.message.text == "Google Sheet key saved and sheets prepared!"
 
 
 def test_store_google_sheet_key_rejects_duplicate_owned_key(tmp_path, monkeypatch):
@@ -150,3 +152,12 @@ def test_store_join_google_sheet_key_requires_registered_owner(tmp_path, monkeyp
     user = db_handler.get_user(2)
     assert user.googlesheet_key is None
     assert user.googlesheet_owner == 0
+@pytest.fixture(autouse=True)
+def mock_sheet_preparation(monkeypatch):
+    """Prevent external API calls during sheet preparation."""
+
+    monkeypatch.setattr("bot_main.reset_sheets", lambda *args, **kwargs: None)
+    monkeypatch.setattr("bot_main.prepare_sheets", lambda *args, **kwargs: None)
+    monkeypatch.setattr("bot_main.initialize_tables", lambda *args, **kwargs: None)
+    monkeypatch.setattr("bot_main.initialize_graphs", lambda *args, **kwargs: None)
+


### PR DESCRIPTION
## Summary
- add an initialize_graphs helper that applies the graph creation template when preparing a sheet
- run the full sheet preparation workflow, including graph setup, from /add_googlesheet and /prepare_sheets
- mock the preparation helpers in bot command tests to avoid external API calls and assert the updated success message

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd5c21a02883328213849d6b9c9ae7