### PR TITLE
Fix graph template pivot table creation

### DIFF
--- a/templates/graph_creation_template.py
+++ b/templates/graph_creation_template.py
@@ -1,0 +1,327 @@
+"""Template for setting up charts on the Graphs sheet."""
+
+GRAPH_CREATION_BODY = {
+    "requests": [
+        {
+            "updateCells": {
+                "start": {
+                    "sheetId": 0,
+                    "rowIndex": 0,
+                    "columnIndex": 0,
+                },
+                "rows": [
+                    {
+                        "values": [
+                            {
+                                "pivotTable": {
+                                    "source": {
+                                        "sheetId": 1,
+                                        "startRowIndex": 1,
+                                        "startColumnIndex": 0,
+                                        "endColumnIndex": 8,
+                                    },
+                                    "rows": [
+                                        {
+                                            "sourceColumnOffset": 0,
+                                            "sortOrder": "DESCENDING",
+                                            "showTotals": False,
+                                            "valueBucket": {
+                                                "values": [
+                                                    {
+                                                        "summarizeFunction": "SUM",
+                                                        "sourceColumnOffset": 3,
+                                                    }
+                                                ]
+                                            },
+                                        }
+                                    ],
+                                    "values": [
+                                        {
+                                            "summarizeFunction": "SUM",
+                                            "sourceColumnOffset": 3,
+                                            "name": "Total Spend",
+                                        }
+                                    ],
+                                    "valueLayout": "HORIZONTAL",
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "fields": "pivotTable",
+            }
+        },
+        {
+            "addChart": {
+                "chart": {
+                    "spec": {
+                        "title": "Top Items by Total Spend",
+                        "basicChart": {
+                            "chartType": "BAR",
+                            "legendPosition": "RIGHT_LEGEND",
+                            "domains": [
+                                {
+                                    "domain": {
+                                        "sourceRange": {
+                                            "sources": [
+                                                {
+                                                    "sheetId": 0,
+                                                    "startRowIndex": 1,
+                                                    "startColumnIndex": 0,
+                                                    "endColumnIndex": 1,
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ],
+                            "series": [
+                                {
+                                    "series": {
+                                        "sourceRange": {
+                                            "sources": [
+                                                {
+                                                    "sheetId": 0,
+                                                    "startRowIndex": 1,
+                                                    "startColumnIndex": 1,
+                                                    "endColumnIndex": 2,
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "targetAxis": "LEFT_AXIS",
+                                }
+                            ],
+                            "axis": [
+                                {"position": "BOTTOM_AXIS", "title": "Items"},
+                                {"position": "LEFT_AXIS", "title": "Total Spend"},
+                            ],
+                        }
+                    },
+                    "position": {
+                        "overlayPosition": {
+                            "anchorCell": {
+                                "sheetId": 0,
+                                "rowIndex": 0,
+                                "columnIndex": 5,
+                            },
+                            "offsetXPixels": 0,
+                            "offsetYPixels": 0,
+                            "widthPixels": 600,
+                            "heightPixels": 400,
+                        }
+                    },
+                }
+            }
+        },
+        {
+            "updateCells": {
+                "start": {
+                    "sheetId": 0,
+                    "rowIndex": 0,
+                    "columnIndex": 12,
+                },
+                "rows": [
+                    {
+                        "values": [
+                            {
+                                "pivotTable": {
+                                    "source": {
+                                        "sheetId": 1,
+                                        "startRowIndex": 1,
+                                        "startColumnIndex": 0,
+                                        "endColumnIndex": 8,
+                                    },
+                                    "rows": [
+                                        {
+                                            "sourceColumnOffset": 5,
+                                            "showTotals": False,
+                                        }
+                                    ],
+                                    "values": [
+                                        {
+                                            "summarizeFunction": "SUM",
+                                            "sourceColumnOffset": 3,
+                                            "name": "Total Spend",
+                                        }
+                                    ],
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "fields": "pivotTable",
+            }
+        },
+        {
+            "addChart": {
+                "chart": {
+                    "spec": {
+                        "title": "Spending by Vendor",
+                        "pieChart": {
+                            "legendPosition": "RIGHT_LEGEND",
+                            "domain": {
+                                "sourceRange": {
+                                    "sources": [
+                                        {
+                                            "sheetId": 0,
+                                            "startRowIndex": 1,
+                                            "startColumnIndex": 12,
+                                            "endColumnIndex": 13,
+                                        }
+                                    ]
+                                }
+                            },
+                            "series": {
+                                "sourceRange": {
+                                    "sources": [
+                                        {
+                                            "sheetId": 0,
+                                            "startRowIndex": 1,
+                                            "startColumnIndex": 13,
+                                            "endColumnIndex": 14,
+                                        }
+                                    ]
+                                }
+                            },
+                        },
+                    },
+                    "position": {
+                        "overlayPosition": {
+                            "anchorCell": {
+                                "sheetId": 0,
+                                "rowIndex": 15,
+                                "columnIndex": 5,
+                            },
+                            "offsetXPixels": 0,
+                            "offsetYPixels": 0,
+                            "widthPixels": 500,
+                            "heightPixels": 400,
+                        }
+                    },
+                }
+            }
+        },
+        {
+            "updateCells": {
+                "start": {
+                    "sheetId": 0,
+                    "rowIndex": 20,
+                    "columnIndex": 0,
+                },
+                "rows": [
+                    {
+                        "values": [
+                            {
+                                "pivotTable": {
+                                    "source": {
+                                        "sheetId": 1,
+                                        "startRowIndex": 1,
+                                        "startColumnIndex": 0,
+                                        "endColumnIndex": 8,
+                                    },
+                                    "rows": [
+                                        {
+                                            "sourceColumnOffset": 6,
+                                            "showTotals": False,
+                                            "sortOrder": "ASCENDING",
+                                            "groupRule": {
+                                                "dateTimeRule": {
+                                                    "type": "YEAR_MONTH",
+                                                }
+                                            },
+                                        }
+                                    ],
+                                    "values": [
+                                        {
+                                            "summarizeFunction": "SUM",
+                                            "sourceColumnOffset": 3,
+                                            "name": "Total Spend",
+                                        }
+                                    ],
+                                    "filterSpecifications": [
+                                        {
+                                            "filterCriteria": {
+                                                "condition": {
+                                                    "type": "DATE_AFTER_RELATIVE",
+                                                    "values": [
+                                                        {"relativeDate": "PAST_SIX_MONTHS"}
+                                                    ],
+                                                }
+                                            },
+                                            "sourceColumnOffset": 6,
+                                        }
+                                    ],
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "fields": "pivotTable",
+            }
+        },
+        {
+            "addChart": {
+                "chart": {
+                    "spec": {
+                        "title": "Monthly Spending (Last 6 Months)",
+                        "basicChart": {
+                            "chartType": "COLUMN",
+                            "legendPosition": "RIGHT_LEGEND",
+                            "domains": [
+                                {
+                                    "domain": {
+                                        "sourceRange": {
+                                            "sources": [
+                                                {
+                                                    "sheetId": 0,
+                                                    "startRowIndex": 21,
+                                                    "startColumnIndex": 0,
+                                                    "endColumnIndex": 1,
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ],
+                            "series": [
+                                {
+                                    "series": {
+                                        "sourceRange": {
+                                            "sources": [
+                                                {
+                                                    "sheetId": 0,
+                                                    "startRowIndex": 21,
+                                                    "startColumnIndex": 1,
+                                                    "endColumnIndex": 2,
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "targetAxis": "LEFT_AXIS",
+                                }
+                            ],
+                            "axis": [
+                                {"position": "BOTTOM_AXIS", "title": "Month"},
+                                {"position": "LEFT_AXIS", "title": "Total Spend"},
+                            ],
+                        }
+                    },
+                    "position": {
+                        "overlayPosition": {
+                            "anchorCell": {
+                                "sheetId": 0,
+                                "rowIndex": 20,
+                                "columnIndex": 5,
+                            },
+                            "offsetXPixels": 0,
+                            "offsetYPixels": 0,
+                            "widthPixels": 600,
+                            "heightPixels": 400,
+                        }
+                    },
+                }
+            }
+        },
+    ]
+}


### PR DESCRIPTION
## Summary
- replace invalid `addPivotTable` requests with `updateCells` pivot definitions so Sheets API accepts the batch update
- keep pivot sources bound to the full item table columns and preserve chart ranges for the graphs sheet

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd590945c083328346d0aeba713c7f