### PR TITLE
Track processed receipts by sheet key

### DIFF
--- a/assistant/db_handler.py
+++ b/assistant/db_handler.py
@@ -36,11 +36,19 @@ def table_init():
         CREATE TABLE IF NOT EXISTS processed_receipts (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             user_telegram_id INTEGER,
-            receipt_number TEXT,       
+            googlesheet_key TEXT,
+            receipt_number TEXT,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (user_telegram_id) REFERENCES users (user_telegram_id)
         )
     ''')
+
+    # Backfill the googlesheet_key column for existing installations that may
+    # predate the schema change.
+    cursor.execute("PRAGMA table_info(processed_receipts)")
+    processed_receipt_columns = {row[1] for row in cursor.fetchall()}
+    if "googlesheet_key" not in processed_receipt_columns:
+        cursor.execute("ALTER TABLE processed_receipts ADD COLUMN googlesheet_key TEXT")
 
     conn.commit()
     conn.close()
@@ -188,24 +196,36 @@ def get_googlesheet_key(user_telegram_id: int) -> str | None:
 
 
 def add_processed_receipt(user_telegram_id: int, receipt_number: str) -> None:
-    """Store a processed receipt number for the given user."""
+    """Store a processed receipt number for the given user and sheet."""
     conn = db_connect()
     cursor = conn.cursor()
     cursor.execute(
-        "INSERT INTO processed_receipts (user_telegram_id, receipt_number) VALUES (?, ?)",
-        (user_telegram_id, receipt_number),
+        "SELECT googlesheet_key FROM users WHERE user_telegram_id = ?",
+        (user_telegram_id,),
+    )
+    row = cursor.fetchone()
+    googlesheet_key = row[0] if row else None
+    cursor.execute(
+        """
+        INSERT INTO processed_receipts (user_telegram_id, googlesheet_key, receipt_number)
+        VALUES (?, ?, ?)
+        """,
+        (user_telegram_id, googlesheet_key, receipt_number),
     )
     conn.commit()
     conn.close()
 
 
-def get_processed_receipts(user_telegram_id: int) -> set[str]:
-    """Retrieve all processed receipt numbers for a given user."""
+def get_processed_receipts(googlesheet_key: str | None) -> set[str]:
+    """Retrieve all processed receipt numbers for a given Google Sheet."""
+    if not googlesheet_key:
+        return set()
+
     conn = db_connect()
     cursor = conn.cursor()
     cursor.execute(
-        "SELECT receipt_number FROM processed_receipts WHERE user_telegram_id = ?",
-        (user_telegram_id,),
+        "SELECT receipt_number FROM processed_receipts WHERE googlesheet_key = ?",
+        (googlesheet_key,),
     )
     receipts = {row[0] for row in cursor.fetchall()}
     conn.close()

--- a/assistant/parser.py
+++ b/assistant/parser.py
@@ -5,7 +5,11 @@ import logging
 import re
 from typing import Any
 
-from assistant.db_handler import add_processed_receipt, get_processed_receipts
+from assistant.db_handler import (
+    add_processed_receipt,
+    get_googlesheet_key,
+    get_processed_receipts,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -58,9 +62,14 @@ class ReceiptParser:
 
     def _check_if_tax_id_new(self) -> bool:
         """Check if the current invoice number has already been processed."""
-        if self.user_telegram_id is None or self.invoice_number is None:
+        if self.invoice_number is None:
             return True
-        processed = get_processed_receipts(self.user_telegram_id)
+
+        googlesheet_key = None
+        if self.user_telegram_id is not None:
+            googlesheet_key = get_googlesheet_key(self.user_telegram_id)
+
+        processed = get_processed_receipts(googlesheet_key)
         return str(self.invoice_number) not in processed
             
 

--- a/bot_main.py
+++ b/bot_main.py
@@ -42,6 +42,11 @@ logger = logging.getLogger(__name__)
 # Define states for ConversationHandler
 WAITING_FOR_IMAGE, WAITING_FOR_SHEET_KEY, WAITING_FOR_JOIN_SHEET_KEY = range(3)
 
+
+def initialize_graphs(*args, **kwargs):
+    """Placeholder hook for initializing dashboard graphs."""
+    return None
+
 def build_main_keyboard(user=None):
     """Return the appropriate keyboard for the user state."""
     buttons = ['/start']

--- a/tests/test_db_handler.py
+++ b/tests/test_db_handler.py
@@ -117,11 +117,22 @@ def test_processed_receipts_functions(tmp_path, monkeypatch):
 
     db_handler.table_init()
     db_handler.add_user(1)
+    db_handler.add_googlesheet_key(1, "sheet123")
     db_handler.add_processed_receipt(1, "123")
     db_handler.add_processed_receipt(1, "456")
 
-    receipts = db_handler.get_processed_receipts(1)
+    receipts = db_handler.get_processed_receipts("sheet123")
     assert receipts == {"123", "456"}
 
-    db_handler.add_user(2)
-    assert db_handler.get_processed_receipts(2) == set()
+    # ensure the googlesheet_key column is populated alongside the telegram id
+    conn = db_handler.db_connect()
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT DISTINCT googlesheet_key FROM processed_receipts WHERE user_telegram_id = ?",
+        (1,),
+    )
+    stored_keys = {row[0] for row in cursor.fetchall()}
+    conn.close()
+    assert stored_keys == {"sheet123"}
+
+    assert db_handler.get_processed_receipts("missing-key") == set()


### PR DESCRIPTION
## Summary
- add a googlesheet_key column to processed_receipts and populate it when archiving receipts
- check processed receipt history by Google Sheet key when parsing new receipts
- update supporting tests and add a placeholder initialize_graphs hook in the bot module

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd736d579c8332b4971fbf3f7ff92d